### PR TITLE
SCT-519: Avoids duplicating features if both CDS and genes are present

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN rm ./hmmer.tar.gz
 
 COPY ./ /kb/module
 RUN mkdir -p /kb/module/work
-RUN chmod 777 /kb/module
+RUN chmod a+rw -R /kb/module
 
 WORKDIR /kb/module
 

--- a/lib/src/domainannotation/DomainAnnotationImpl.java
+++ b/lib/src/domainannotation/DomainAnnotationImpl.java
@@ -425,6 +425,9 @@ public class DomainAnnotationImpl {
                     List<Feature> features = genome.getFeatures();
                     int pos = -1;
                     for (Feature feat : features) {
+                        if (feat.getAdditionalProperties().containsKey("parent_gene")){
+                            continue;
+                        }
                         pos++;
                         String seq = feat.getProteinTranslation();
                         if (feat.getLocation().size() < 1)


### PR DESCRIPTION
As we discussed in slack, this skips CDSs with a "parent_gene" because if a parent gene is set, the protein sequence has already been copied to the gene